### PR TITLE
Update stylelint peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "stylelint": "^8.0.0"
   },
   "peerDependencies": {
-    "stylelint": "^7.13.0 || ^8.0.0"
+    "stylelint": "^7.13.0 || ^8.0.0 || ^9.0.0"
   },
   "scripts": {
     "lint": "eslint *.js && check-es3-syntax --kill --print *.js"


### PR DESCRIPTION
Update the peer dependency of stylelint to also include `stylelint@^9.0.0`.